### PR TITLE
Documentation for the programmatic API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,15 @@ $ python main.py -h
 ```
 
 ```lang-none
+SerpApi SEO Keyword Research Tool [-h] -q  [-e  [...]] [-dl] [-st] [-ak] [-gd] [-gl] [-hl]
+
 Extract keywrods from: Google Autocomplete, People Also Ask, and People Also Search and saves data to CSV/JSON/TXT.
 
 optional arguments:
   -h, --help            show this help message and exit
   -q , --query          Search query (required).
-  -e , --engines        Choices of engines to extract: Autocomplete (ac), Related Searches (rs), People Also Ask (rq). All engines are selected by default.
+  -e  [ ...], --engines  [ ...]
+                        Choices of engines to extract: Autocomplete (ac), Related Searches (rs), People Also Ask (rq). You can select multiple engines. All engines are selected by default.
   -dl , --depth-limit   Depth limit for People Also Ask. Default is 0, first 2-4 results.
   -st , --save-to       Saves the results in the current directory in the selected format (CSV, JSON, TXT). Default CSV.
   -ak , --api-key       Your SerpApi API key: https://serpapi.com/manage-api-key. Default is a test API key to test CLI.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ $ python main.py -q "starbucks coffee"
 }
 ```
 
-#### Advanced example
+#### Advanced example:
 
 This example will use [related questions API](https://serpapi.com/related-questions) engine with a depth limit value of 2, and saves data to JSON:
 
@@ -150,6 +150,32 @@ $ python main.py --api-key <your_serpapi_api_key> \
     "Do Starbucks employees get free food?"
   ]
 }
+```
+
+#### Example of manual data extraction (without CLI):
+
+```python
+from seo_keyword_research import SeoKeywordResearch
+
+keyword_research = SeoKeywordResearch(
+    query='starbucks coffee',
+    api_key='<your_serpapi_api_key>',
+    lang='en',
+    country='us',
+    domain='google.com'
+)
+
+auto_complete_results = keyword_research.get_auto_complete()
+related_searches_results = keyword_research.get_related_searches()
+related_questions_results = keyword_research.get_related_questions()
+
+data = {
+    'auto_complete': auto_complete_results,
+    'related_searches': related_searches_results,
+    'related_questions': related_questions_results
+}
+
+keyword_research.print_data(data)
 ```
 
 ### ✍Contributing

--- a/example.py
+++ b/example.py
@@ -2,7 +2,7 @@ from seo_keyword_research import SeoKeywordResearch
 
 keyword_research = SeoKeywordResearch(
     query='starbucks coffee',
-    api_key='5868ece26d41221f5e19ae8b3e355d22db23df1712da675d144760fc30d57988',
+    api_key='<your_serpapi_api_key>',
     lang='en',
     country='us',
     domain='google.com'

--- a/example.py
+++ b/example.py
@@ -1,0 +1,21 @@
+from seo_keyword_research import SeoKeywordResearch
+
+keyword_research = SeoKeywordResearch(
+    query='starbucks coffee',
+    api_key='5868ece26d41221f5e19ae8b3e355d22db23df1712da675d144760fc30d57988',
+    lang='en',
+    country='us',
+    domain='google.com'
+)
+
+auto_complete_results = keyword_research.get_auto_complete()
+related_searches_results = keyword_research.get_related_searches()
+related_questions_results = keyword_research.get_related_questions()
+
+data = {
+    'auto_complete': auto_complete_results,
+    'related_searches': related_searches_results,
+    'related_questions': related_questions_results
+}
+
+keyword_research.print_data(data)

--- a/main.py
+++ b/main.py
@@ -37,9 +37,7 @@ def main():
             data['related_questions'] = keyword_research.get_related_questions(args.depth_limit)
 
     if data:
-        keyword_research.print_data(data)
-
-    if args.save_to:
+        # keyword_research.print_data(data)
         print(f'Saving data in {args.save_to.upper()} format...')
 
         if args.save_to.upper() == 'CSV':

--- a/main.py
+++ b/main.py
@@ -1,113 +1,5 @@
-from serpapi import GoogleSearch
-from itertools import zip_longest
-import json, csv, argparse
-
-
-def get_auto_complete(query: str, country: str, lang: str, api_key: str):
-    params = {
-        'api_key': api_key,                         # https://serpapi.com/manage-api-key
-        'engine': 'google_autocomplete',            # search engine
-        'q': query,                                 # search query
-        'gl': country,                              # https://serpapi.com/google-countries
-        'hl': lang                                  # https://serpapi.com/google-languages
-    }
-
-    search = GoogleSearch(params)                   # data extraction on the SerpApi backend
-    results = search.get_dict()                     # JSON -> Python dict
-    
-    auto_complete_results = [result['value'] for result in results['suggestions']]
-    
-    return auto_complete_results
-
-
-def get_related_searches(query: str, domain: str, country: str, lang: str, api_key: str):
-    params = {
-        'api_key': api_key,                         # https://serpapi.com/manage-api-key
-        'engine': 'google',                         # search engine
-        'q': query,                                 # search query
-        'google_domain': domain,                    # https://serpapi.com/google-domains
-        'gl': country,                              # https://serpapi.com/google-countries
-        'hl': lang                                  # https://serpapi.com/google-languages
-    }
-
-    search = GoogleSearch(params)                   # data extraction on the SerpApi backend
-    results = search.get_dict()                     # JSON -> Python dict
-    
-    related_searches_results = [result['query'] for result in results['related_searches']]
-
-    return related_searches_results
-
-
-def get_related_questions(query: str, domain: str, country: str, lang: str, api_key: str, depth_limit: int):
-    params = {
-        'api_key': api_key,                         # https://serpapi.com/manage-api-key
-        'engine': 'google',                         # search engine
-        'q': query,                                 # search query
-        'google_domain': domain,                    # https://serpapi.com/google-domains
-        'gl': country,                              # https://serpapi.com/google-countries
-        'hl': lang                                  # https://serpapi.com/google-languages
-    }
-
-    search = GoogleSearch(params)                   # data extraction on the SerpApi backend
-    results = search.get_dict()                     # JSON -> Python dict
-
-    related_questions_results = [result['question'] for result in results['related_questions']]
-
-    if depth_limit:
-        def get_depth_results(token, depth, api_key):
-            ''' This function allows you to extract more data from People Also Ask.
-            
-            The function takes the following arguments:
-            
-            - `token` - allows access to additional related questions;
-            
-            - `depth` - limits the input depth for each related question;
-            
-            - `api_key` - your SerpApi API key. '''
-
-            depth_params = {
-                'api_key': api_key,
-                'engine': 'google_related_questions',
-                'next_page_token': token,
-            }
-
-            depth_search = GoogleSearch(depth_params)
-            depth_results = depth_search.get_dict()
-            
-            related_questions_results.extend([result['question'] for result in depth_results.get('related_questions', [])])
-            
-            if depth > 1:
-                for question in depth_results.get('related_questions', []):
-                    if question.get('next_page_token'):
-                        get_depth_results(question.get('next_page_token'), depth - 1, api_key)
-                    
-        for question in results.get('related_questions', []):
-            if question.get('next_page_token'):
-                get_depth_results(question.get('next_page_token'), depth_limit, api_key)
-        
-    return related_questions_results
-
-
-def save_to_csv(data: dict):
-    with open('data.csv', 'w') as csv_file:
-        writer = csv.writer(csv_file)
-        writer.writerow(data.keys())
-        writer.writerows(zip_longest(*data.values()))
-
-
-def save_to_json(data: dict):
-    with open('data.json', 'w', encoding='utf-8') as json_file:
-        json.dump(data, json_file, indent=2, ensure_ascii=False)
-
-
-def save_to_txt(data: dict):
-    with open('data.txt', 'w') as txt_file:
-        for key in data.keys():
-            txt_file.write('\n'.join(data[key]) + '\n')
-
-
-def print_data(data: dict):
-    print(json.dumps(data, indent=2, ensure_ascii=False))
+from seo_keyword_research import SeoKeywordResearch
+import argparse
 
 
 def main():
@@ -117,43 +9,45 @@ def main():
         epilog='Found a bug? Open issue: https://github.com/chukhraiartur/seo-keyword-research-tool/issues'
     )
     parser.add_argument('-q','--query', metavar='', required=True, help='Search query (required).')
-    parser.add_argument('-e','--engines', metavar='', required=False, default='all', choices=['ac', 'rs', 'rq'], help='Choices of engines to extract: Autocomplete (ac), Related Searches (rs), People Also Ask (rq). All engines are selected by default.')
+    parser.add_argument('-e','--engines', metavar='', required=False, type=str, default=['ac', 'rs', 'rq'], nargs='+', help='Choices of engines to extract: Autocomplete (ac), Related Searches (rs), People Also Ask (rq). You can select multiple engines. All engines are selected by default.')
     parser.add_argument('-dl','--depth-limit', metavar='', required=False, type=int, default=0, help='Depth limit for People Also Ask. Default is %(default)i, first 2-4 results.')
     parser.add_argument('-st','--save-to', metavar='', required=False, default='CSV', help='Saves the results in the current directory in the selected format (CSV, JSON, TXT). Default %(default)s.')
     parser.add_argument('-ak','--api-key', metavar='', required=False, default='5868ece26d41221f5e19ae8b3e355d22db23df1712da675d144760fc30d57988', help='Your SerpApi API key: https://serpapi.com/manage-api-key. Default is a test API key to test CLI.')
     parser.add_argument('-gd','--domain', metavar='', required=False, default='google.com', help='Google domain: https://serpapi.com/google-domains. Default %(default)s.')
     parser.add_argument('-gl','--country', metavar='', required=False, default='us', help='Country of the search: https://serpapi.com/google-countries. Default %(default)s.')
     parser.add_argument('-hl','--lang', metavar='', required=False, default='en', help='Language of the search: https://serpapi.com/google-languages. Default %(default)s.')
-
     args = parser.parse_args()
     
+    keyword_research = SeoKeywordResearch(
+        query=args.query,
+        api_key=args.api_key,
+        lang=args.lang,
+        country=args.country,
+        domain=args.domain
+    )
+
     data = {}
     
-    if args.depth_limit > 4:
-        args.depth_limit = 4
+    for engine in args.engines:
+        if engine.lower() == 'ac':
+            data['auto_complete'] = keyword_research.get_auto_complete()
+        elif engine.lower() == 'rs':
+            data['related_searches'] = keyword_research.get_related_searches()
+        elif engine.lower() == 'rq':
+            data['related_questions'] = keyword_research.get_related_questions(args.depth_limit)
 
-    if 'all' in args.engines:
-        data['auto_complete'] = get_auto_complete(args.query, args.country, args.lang, args.api_key)
-        data['related_searches'] = get_related_searches(args.query, args.domain, args.country, args.lang, args.api_key)
-        data['related_questions'] = get_related_questions(args.query, args.domain, args.country, args.lang, args.api_key, args.depth_limit)
-    elif 'ac' in args.engines:
-        data['auto_complete'] = get_auto_complete(args.query, args.country, args.lang, args.api_key)
-    elif 'rs' in args.engines:
-        data['related_searches'] = get_related_searches(args.query, args.domain, args.country, args.lang, args.api_key)
-    elif 'rq' in args.engines:
-        data['related_questions'] = get_related_questions(args.query, args.domain, args.country, args.lang, args.api_key, args.depth_limit)
-
-    # print_data(data)
+    if data:
+        keyword_research.print_data(data)
 
     if args.save_to:
         print(f'Saving data in {args.save_to.upper()} format...')
 
         if args.save_to.upper() == 'CSV':
-            save_to_csv(data)
+            keyword_research.save_to_csv(data)
         elif args.save_to.upper() == 'JSON':
-            save_to_json(data)
+            keyword_research.save_to_json(data)
         elif args.save_to.upper() == 'TXT':
-            save_to_txt(data)
+            keyword_research.save_to_txt(data)
 
         print(f'Data successfully saved to data.{args.save_to.lower()} file')
 

--- a/seo_keyword_research.py
+++ b/seo_keyword_research.py
@@ -1,0 +1,120 @@
+from serpapi import GoogleSearch
+from itertools import zip_longest
+import json, csv
+
+
+class SeoKeywordResearch:
+    def __init__(self, query: str, api_key: str, lang: str = 'en', country: str = 'us', domain: str = 'google.com') -> None:
+        self.query = query
+        self.api_key = api_key
+        self.lang = lang
+        self.country = country
+        self.domain = domain
+
+
+    def get_auto_complete(self) -> list:
+        params = {
+            'api_key': self.api_key,            # https://serpapi.com/manage-api-key
+            'engine': 'google_autocomplete',    # search engine
+            'q': self.query,                    # search query
+            'gl': self.country,                 # country of the search
+            'hl': self.lang                     # language of the search
+        }
+
+        search = GoogleSearch(params)           # data extraction on the SerpApi backend
+        results = search.get_dict()             # JSON -> Python dict
+        
+        auto_complete_results = [result.get('value') for result in results.get('suggestions', [])]
+        
+        return auto_complete_results
+
+
+    def get_related_searches(self) -> list:
+        params = {
+            'api_key': self.api_key,            # https://serpapi.com/manage-api-key
+            'engine': 'google',                 # search engine
+            'q': self.query,                    # search query
+            'google_domain': self.domain,       # Google domain to use
+            'gl': self.country,                 # country of the search
+            'hl': self.lang                     # language of the search
+        }
+
+        search = GoogleSearch(params)           # data extraction on the SerpApi backend
+        results = search.get_dict()             # JSON -> Python dict
+        
+        related_searches_results = [result.get('query') for result in results.get('related_searches', [])]
+
+        return related_searches_results
+
+
+    def get_related_questions(self, depth_limit: int = 0) -> list:
+        params = {
+            'api_key': self.api_key,            # https://serpapi.com/manage-api-key
+            'engine': 'google',                 # search engine
+            'q': self.query,                    # search query
+            'google_domain': self.domain,       # Google domain to use
+            'gl': self.country,                 # country of the search
+            'hl': self.lang                     # language of the search
+        }
+
+        search = GoogleSearch(params)           # data extraction on the SerpApi backend
+        results = search.get_dict()             # JSON -> Python dict
+
+        related_questions_results = [result.get('question') for result in results.get('related_questions', [])]
+
+        if depth_limit > 4:
+            depth_limit = 4
+
+        if depth_limit:
+            def get_depth_results(token: str, depth: int) -> None:
+                ''' This function allows you to extract more data from People Also Ask.
+                
+                The function takes the following arguments:
+                
+                - `token` - allows access to additional related questions;
+                
+                - `depth` - limits the input depth for each related question. '''
+
+                depth_params = {
+                    'api_key': self.api_key,
+                    'engine': 'google_related_questions',
+                    'next_page_token': token,
+                }
+
+                depth_search = GoogleSearch(depth_params)
+                depth_results = depth_search.get_dict()
+                
+                related_questions_results.extend([result.get('question') for result in depth_results.get('related_questions', [])])
+                
+                if depth > 1:
+                    for question in depth_results.get('related_questions', []):
+                        if question.get('next_page_token'):
+                            get_depth_results(question.get('next_page_token'), depth - 1)
+                        
+            for question in results.get('related_questions', []):
+                if question.get('next_page_token'):
+                    get_depth_results(question.get('next_page_token'), depth_limit)
+            
+        return related_questions_results
+
+
+    def save_to_csv(self, data: dict) -> None:
+        with open('data.csv', 'w') as csv_file:
+            writer = csv.writer(csv_file)
+            writer.writerow(data.keys())
+            writer.writerows(zip_longest(*data.values()))
+
+
+    def save_to_json(self, data: dict) -> None:
+        with open('data.json', 'w', encoding='utf-8') as json_file:
+            json.dump(data, json_file, indent=2, ensure_ascii=False)
+
+
+    def save_to_txt(self, data: dict) -> None:
+        with open('data.txt', 'w') as txt_file:
+            for key in data.keys():
+                txt_file.write('\n'.join(data.get(key)) + '\n')
+
+
+    def print_data(self, data: dict) -> None:
+        print(json.dumps(data, indent=2, ensure_ascii=False))

--- a/seo_keyword_research.py
+++ b/seo_keyword_research.py
@@ -67,13 +67,14 @@ class SeoKeywordResearch:
 
         if depth_limit:
             def get_depth_results(token: str, depth: int) -> None:
-                ''' This function allows you to extract more data from People Also Ask.
+                '''
+                This function allows you to extract more data from People Also Ask.
                 
                 The function takes the following arguments:
                 
-                - `token` - allows access to additional related questions;
-                
-                - `depth` - limits the input depth for each related question. '''
+                :param token: allows access to additional related questions.
+                :param depth: limits the input depth for each related question.
+                '''
 
                 depth_params = {
                     'api_key': self.api_key,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     name='seo-keyword-research-tool',
     description = 'Python SEO keywords suggestion tool. Google Autocomplete, Related Questions and Related Searches.',
     url='https://github.com/chukhraiartur/seo-keyword-research-tool',
-    version='0.1.3',
+    version='0.1.4',
     license='MIT',
     author='Artur Chukhrai',
     author_email='chukhraiartur@gmail.com',


### PR DESCRIPTION
Closes #1 

In this update, you can now use the `SeoKeywordResearch` class and call the `get_auto_complete()`, `get_related_searches()` and `get_related_questions()` methods manually.

Tasks:

- [x] Add a class that can be used to manually call methods
- [x] Add an example of the use
- [x] Update README.md